### PR TITLE
Add module definitions

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -2,7 +2,6 @@
 
 export {
   Injector,
-  IModule,
   IValueModule,
   IClassModule,
   IFactoryModule,

--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,13 @@
 // PUBLIC API
 
-export {Injector} from './lib/injector';
+export {
+  Injector,
+  IModule,
+  IValueModule,
+  IClassModule,
+  IFactoryModule,
+  Module
+} from './lib/injector';
 export {createToken} from './lib/opaqueToken';
 export {
   annotate,


### PR DESCRIPTION
The `Module` was not exported from the main module `index.ts`.
I have included the relevant interfaces being typed against: `IValueModule`, `IClassModule` and `IFactoryModule`

Use case:

I am writing a module decorator (similar lines to Angular)
```
import { Module } from 'di-typescript';

export interface GsModule {
    providers?: Module[];
}

```